### PR TITLE
Revised the part of Week 01 about adding gitbash as the terminal.

### DIFF
--- a/Week_01_--_VS_Code_and_Git_Notes/030_Terminal_Operations.md
+++ b/Week_01_--_VS_Code_and_Git_Notes/030_Terminal_Operations.md
@@ -82,6 +82,14 @@ Why would this be a problem? <span class="code">/images/file.png</span>
 * [82 part tutorial](https://www.youtube.com/playlist?list=PLS1QulWo1RIb9WVQGJ_vh-RQusbZgO_As)
 * [Nixie Pixel video](https://www.youtube.com/watch?v=q7-aEspwwEI) I think she probably drinks too much caffein, but you might benefit by watching what she does.
 
+## Using Gitbash as the terminal in VScode
+
+This seems to be getting easier.  In the current version (1.30) it looks like the first time you open Code it asks what shell you want to use.  If you already have git and gitbash installed then gitbash should be an option.
+
+If not, you can go to File --> Preferences --> Settings, then pick "Features" and "Terminal."  Find the entry for "External: Windows exec:" and paste the following:
+
+    C:\Program Files\Git\bin\bash.exe
+
 ## Editors
 
 Generally we will just use a gui editor, but there are native editors built into linux.  Sometimes you just need them.


### PR DESCRIPTION
Simplified instructions for adding gitbash as the default terminal shell.

This worked for VScode 1.30 on Windows.